### PR TITLE
feat: Implement sign-up functionality with user profiles

### DIFF
--- a/create_user_trigger.sql
+++ b/create_user_trigger.sql
@@ -1,0 +1,14 @@
+-- Function to create a new user profile
+create function public.handle_new_user()
+returns trigger as $$
+begin
+  insert into public.users (id, email)
+  values (new.id, new.email);
+  return new;
+end;
+$$ language plpgsql security definer;
+
+-- Trigger to call the function when a new user is created
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute procedure public.handle_new_user();

--- a/create_users_table.sql
+++ b/create_users_table.sql
@@ -1,0 +1,20 @@
+-- Create the public.users table
+create table public.users (
+  id uuid not null primary key,
+  email text,
+  full_name text,
+  role text default 'user'
+);
+
+-- Set up Row Level Security (RLS)
+alter table public.users enable row level security;
+
+-- Create a policy to allow users to view their own profile
+create policy "Users can view their own profile"
+on public.users for select
+using ( auth.uid() = id );
+
+-- Create a policy to allow users to update their own profile
+create policy "Users can update their own profile"
+on public.users for update
+using ( auth.uid() = id );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 import LoginPage from './pages/LoginPage';
+import SignUpPage from './pages/SignUpPage';
 import DashboardPage from './pages/DashboardPage';
 import PrivateRoute from './components/PrivateRoute';
 
@@ -8,6 +9,7 @@ function App() {
     <Routes>
       <Route path="/" element={<Navigate to="/login" />} />
       <Route path="/login" element={<LoginPage />} />
+      <Route path="/signup" element={<SignUpPage />} />
       <Route element={<PrivateRoute />}>
         <Route path="/dashboard" element={<DashboardPage />} />
       </Route>

--- a/src/pages/SignUpPage.jsx
+++ b/src/pages/SignUpPage.jsx
@@ -3,19 +3,21 @@ import { useNavigate, Link } from 'react-router-dom';
 import { Button, TextField, Container, Typography, Box, Alert, Grid } from '@mui/material';
 import { supabase } from '../services/supabase';
 
-const LoginPage = () => {
+const SignUpPage = () => {
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
 
-  const handleLogin = async (e) => {
+  const handleSignUp = async (e) => {
     e.preventDefault();
     setError('');
+    setMessage('');
     try {
-      const { error } = await supabase.auth.signInWithPassword({ email, password });
+      const { error } = await supabase.auth.signUp({ email, password });
       if (error) throw error;
-      navigate('/dashboard');
+      setMessage('Check your email for the confirmation link!');
     } catch (error) {
       setError(error.message);
     }
@@ -32,10 +34,11 @@ const LoginPage = () => {
         }}
       >
         <Typography component="h1" variant="h5">
-          Sign in
+          Sign up
         </Typography>
         {error && <Alert severity="error" sx={{ mt: 2, width: '100%' }}>{error}</Alert>}
-        <Box component="form" onSubmit={handleLogin} noValidate sx={{ mt: 1 }}>
+        {message && <Alert severity="success" sx={{ mt: 2, width: '100%' }}>{message}</Alert>}
+        <Box component="form" onSubmit={handleSignUp} noValidate sx={{ mt: 1 }}>
           <TextField
             margin="normal"
             required
@@ -56,7 +59,7 @@ const LoginPage = () => {
             label="Password"
             type="password"
             id="password"
-            autoComplete="current-password"
+            autoComplete="new-password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
           />
@@ -66,12 +69,12 @@ const LoginPage = () => {
             variant="contained"
             sx={{ mt: 3, mb: 2 }}
           >
-            Sign In
+            Sign Up
           </Button>
           <Grid container justifyContent="flex-end">
             <Grid item>
-              <Link to="/signup" variant="body2">
-                {"Don't have an account? Sign Up"}
+              <Link to="/login" variant="body2">
+                {"Already have an account? Sign In"}
               </Link>
             </Grid>
           </Grid>
@@ -81,4 +84,4 @@ const LoginPage = () => {
   );
 };
 
-export default LoginPage;
+export default SignUpPage;


### PR DESCRIPTION
This commit introduces a new sign-up page and the backend infrastructure to support user profiles.

Key changes:
- Created a `public.users` table to store user profile data.
- Added a database trigger to automatically populate the `public.users` table upon user sign-up.
- Implemented a new sign-up page with a form to register new users.
- Updated the application's routing to include the `/signup` route.
- Added navigation links between the sign-in and sign-up pages.
- Included the SQL scripts for creating the table and trigger.